### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,18 +1,18 @@
 # SC::Communicator Class
 Communicator	KEYWORD3
 Send	KEYWORD2
-MessagesAvailable   KEYWORD2
+MessagesAvailable	KEYWORD2
 Receive	KEYWORD2
 Spin	KEYWORD2
-pQueueSize  KEYWORD2
+pQueueSize	KEYWORD2
 pReceiptTimeout	KEYWORD2
-pMaxRetries KEYWORD2
+pMaxRetries	KEYWORD2
 
 # SC::Message Class
 Message	KEYWORD3
 SetData	KEYWORD2
 GetData	KEYWORD2
-pID KEYWORD2
-pPriority   KEYWORD2
-pDataLength KEYWORD2
+pID	KEYWORD2
+pPriority	KEYWORD2
+pDataLength	KEYWORD2
 pMessageLength	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords